### PR TITLE
Update script.js: usa a melhor avaliação ao invés da última.

### DIFF
--- a/script.js
+++ b/script.js
@@ -62,9 +62,19 @@ async function getContent(comment, repo, owner, pullRequest) {
 async function getPull(owner, repo, pullRequest) {
   const response = await fetch(`${baseURL}repos/${owner}/${repo}/issues/${pullRequest}/comments?per_page=100`);
   const data = await response.json();
-  const lastComment = data[data.length - 1].body;
+  let percentage = 0;
+  let commentIndex = 0;
+  data.forEach((item, index) => {
+    if (item.body[4] === 'R') {
+      if (parseFloat(item.body.match(/(?<=totais \| ).*/i)[0]) > percentage) {
+        percentage = parseFloat(item.body.match(/(?<=totais \| ).*/i)[0]);
+        commentIndex = index;
+      }
+    }
+  })
+  const bestComment = data[commentIndex].body
 
-  const content = await getContent(lastComment, repo, owner, pullRequest);
+  const content = await getContent(bestComment, repo, owner, pullRequest);
   const [ userName ] = content;
   createTable(content);
   saveLocalStorage(repo, pullRequest, userName);

--- a/script.js
+++ b/script.js
@@ -71,8 +71,8 @@ async function getPull(owner, repo, pullRequest) {
         commentIndex = index;
       }
     }
-  })
-  const bestComment = data[commentIndex].body
+  });
+  const bestComment = data[commentIndex].body;
 
   const content = await getContent(bestComment, repo, owner, pullRequest);
   const [ userName ] = content;


### PR DESCRIPTION
Bom dia Lucas,

Achei muito irado o seu projeto pra facilitar a visualização do status dos projetos.

Ao analisar o código e o funcionamento dele eu percebi que ele sempre usava o último comment(avaliação) feito no PR, mesmo que ela não fosse a melhor avaliação (maior %). Como eu estava sem sono resolvi brincar um pouco no seu código pra tentar ver se conseguia resolver esse "bug".

Fica a seu critério adotar ou não as mudanças, espero que não se importe de eu ter mexido com seu código. Vou deixar aqui embaixo uma explicação linha a linha pra facilitar a compreensão das mudanças que eu fiz.

Linha 65: valor 0 para ser usado como porcentagem inicial no forEach;
Linha 66: index 0 usado como padrão caso não exista comment com porcentagem maior que 0%;
Linha 67: forEach iterando o array data;
Linha 68: If usado para ignorar todos os comments que são verificação de lint;
Linha 69: Compara a porcentagem do comment atual com a mais alta registrada até então;
Linha 70: Atualiza a porcentagem salva caso a atual seja mais alta do que a registrada anteriormente;
Linha 71: Atualiza a variável commentIndex com o index do comment atual;
Linha 75: Comment com a % mais alta encontrada (caso exista mais de um comment com essa %, será usado o primeiro que foi encontrado);
Linha 77: Atualiza o nome do primeiro argumento passado para a função getContent.

Abç.